### PR TITLE
Release/4.3.0

### DIFF
--- a/Gibe.Umbraco.V7.Blog/Filters/AtLeastOneMatchingTagFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/AtLeastOneMatchingTagFilter.cs
@@ -8,8 +8,6 @@ namespace Gibe.Umbraco.Blog.Filters
 	{
 		public IEnumerable<string> Tags { get; }
 
-		public AtLeastOneMatchingTagFilter() { }
-
 		public AtLeastOneMatchingTagFilter(IEnumerable<string> tags)
 		{
 			Tags = tags;

--- a/Gibe.Umbraco.V7.Blog/Filters/AtLeastOneMatchingTagFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/AtLeastOneMatchingTagFilter.cs
@@ -6,18 +6,18 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class AtLeastOneMatchingTagFilter : IBlogPostFilter
 	{
-		private readonly IEnumerable<string> _tags;
+		public IEnumerable<string> Tags { get; }
+
+		public AtLeastOneMatchingTagFilter() { }
 
 		public AtLeastOneMatchingTagFilter(IEnumerable<string> tags)
 		{
-			_tags = tags;
+			Tags = tags;
 		}
 		
 		public IBooleanOperation GetCriteria(IQuery query)
 		{
-			return query.GroupedOr(new []{"tag"}, _tags.ToArray());
+			return query.GroupedOr(new []{"tag"}, Tags.ToArray());
 		}
-
-		public IEnumerable<string> Tags => _tags;
 	}
 }

--- a/Gibe.Umbraco.V7.Blog/Filters/AuthorBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/AuthorBlogPostFilter.cs
@@ -1,0 +1,22 @@
+﻿using Examine.SearchCriteria;
+using Gibe.Umbraco.Blog.Utilities;
+
+namespace Gibe.Umbraco.Blog.Filters
+{
+	public class AuthorBlogPostFilter : IBlogPostFilter
+	{
+		public string Author { get; set; }
+
+		public AuthorBlogPostFilter() { }
+
+		public AuthorBlogPostFilter(string author)
+		{
+			Author = author;
+		}
+
+		public IBooleanOperation GetCriteria(IQuery query)
+		{
+			return query.Field("postAuthorName", new ExactPhraseExamineValue(Author.ToLower()));
+		}
+	}
+}

--- a/Gibe.Umbraco.V7.Blog/Filters/AuthorBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/AuthorBlogPostFilter.cs
@@ -7,8 +7,6 @@ namespace Gibe.Umbraco.Blog.Filters
 	{
 		public string Author { get; set; }
 
-		public AuthorBlogPostFilter() { }
-
 		public AuthorBlogPostFilter(string author)
 		{
 			Author = author;

--- a/Gibe.Umbraco.V7.Blog/Filters/AuthorBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/AuthorBlogPostFilter.cs
@@ -5,7 +5,7 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class AuthorBlogPostFilter : IBlogPostFilter
 	{
-		public string Author { get; set; }
+		public string Author { get; }
 
 		public AuthorBlogPostFilter(string author)
 		{

--- a/Gibe.Umbraco.V7.Blog/Filters/CategoryBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/CategoryBlogPostFilter.cs
@@ -5,7 +5,7 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class CategoryBlogPostFilter : IBlogPostFilter
 	{
-		public string CategoryName { get; set; }
+		public string CategoryName { get; }
 
 		public CategoryBlogPostFilter(string categoryName)
 		{

--- a/Gibe.Umbraco.V7.Blog/Filters/CategoryBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/CategoryBlogPostFilter.cs
@@ -1,0 +1,22 @@
+﻿using Examine.SearchCriteria;
+using Gibe.Umbraco.Blog.Utilities;
+
+namespace Gibe.Umbraco.Blog.Filters
+{
+	public class CategoryBlogPostFilter : IBlogPostFilter
+	{
+		public string CategoryName { get; set; }
+
+		public CategoryBlogPostFilter() { }
+
+		public CategoryBlogPostFilter(string categoryName)
+		{
+			CategoryName = categoryName;
+		}
+
+		public IBooleanOperation GetCriteria(IQuery query)
+		{
+			return query.Field("categoryName", new ExactPhraseExamineValue(CategoryName.ToLower()));
+		}
+	}
+}

--- a/Gibe.Umbraco.V7.Blog/Filters/CategoryBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/CategoryBlogPostFilter.cs
@@ -7,8 +7,6 @@ namespace Gibe.Umbraco.Blog.Filters
 	{
 		public string CategoryName { get; set; }
 
-		public CategoryBlogPostFilter() { }
-
 		public CategoryBlogPostFilter(string categoryName)
 		{
 			CategoryName = categoryName;

--- a/Gibe.Umbraco.V7.Blog/Filters/DateBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/DateBlogPostFilter.cs
@@ -4,28 +4,30 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class DateBlogPostFilter : IBlogPostFilter
 	{
-		private readonly int _year;
-		private readonly int? _month;
-		private readonly int? _day;
+		public int Year { get; set; }
+		public int? Month { get; set; }
+		public int? Day { get; set; }
+
+		public DateBlogPostFilter() { }
 
 		public DateBlogPostFilter(int year, int? month, int? day)
 		{
-			_year = year;
-			_month = month;
-			_day = day;
+			Year = year;
+			Month = month;
+			Day = day;
 		}
 		
 		public IBooleanOperation GetCriteria(IQuery query)
 		{
-			var output = query.Field("postDateYear", _year.ToString("00"));
+			var output = query.Field("postDateYear", Year.ToString("00"));
 
-			if (_month.HasValue)
+			if (Month.HasValue)
 			{
-				output = output.And().Field("postDateMonth", _month.Value.ToString("00"));
+				output = output.And().Field("postDateMonth", Month.Value.ToString("00"));
 			}
-			if (_day.HasValue)
+			if (Day.HasValue)
 			{
-				output = output.And().Field("postDateDay", _day.Value.ToString("00"));
+				output = output.And().Field("postDateDay", Day.Value.ToString("00"));
 			}
 			return output;
 		}

--- a/Gibe.Umbraco.V7.Blog/Filters/DateBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/DateBlogPostFilter.cs
@@ -4,9 +4,9 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class DateBlogPostFilter : IBlogPostFilter
 	{
-		public int Year { get; set; }
-		public int? Month { get; set; }
-		public int? Day { get; set; }
+		public int Year { get; }
+		public int? Month { get; }
+		public int? Day { get; }
 
 		public DateBlogPostFilter(int year, int? month, int? day)
 		{

--- a/Gibe.Umbraco.V7.Blog/Filters/DateBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/DateBlogPostFilter.cs
@@ -8,8 +8,6 @@ namespace Gibe.Umbraco.Blog.Filters
 		public int? Month { get; set; }
 		public int? Day { get; set; }
 
-		public DateBlogPostFilter() { }
-
 		public DateBlogPostFilter(int year, int? month, int? day)
 		{
 			Year = year;

--- a/Gibe.Umbraco.V7.Blog/Filters/SearchTermBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/SearchTermBlogPostFilter.cs
@@ -4,7 +4,7 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class SearchTermBlogPostFilter : IBlogPostFilter
 	{
-		public string SearchTerm { get; set; }
+		public string SearchTerm { get; }
 
 		public SearchTermBlogPostFilter(string searchTerm)
 		{

--- a/Gibe.Umbraco.V7.Blog/Filters/SearchTermBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/SearchTermBlogPostFilter.cs
@@ -6,8 +6,6 @@ namespace Gibe.Umbraco.Blog.Filters
 	{
 		public string SearchTerm { get; set; }
 
-		public SearchTermBlogPostFilter() { }
-
 		public SearchTermBlogPostFilter(string searchTerm)
 		{
 			SearchTerm = searchTerm;

--- a/Gibe.Umbraco.V7.Blog/Filters/SearchTermBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/SearchTermBlogPostFilter.cs
@@ -4,16 +4,18 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class SearchTermBlogPostFilter : IBlogPostFilter
 	{
-		private readonly string _searchTerm;
+		public string SearchTerm { get; set; }
+
+		public SearchTermBlogPostFilter() { }
 
 		public SearchTermBlogPostFilter(string searchTerm)
 		{
-			_searchTerm = searchTerm;
+			SearchTerm = searchTerm;
 		}
 
 		public IBooleanOperation GetCriteria(IQuery query)
 		{
-			return query.Field("bodyText", _searchTerm);
+			return query.Field("bodyText", SearchTerm);
 		}
 	}
 }

--- a/Gibe.Umbraco.V7.Blog/Filters/SectionBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/SectionBlogPostFilter.cs
@@ -6,8 +6,6 @@ namespace Gibe.Umbraco.Blog.Filters
 	{
 		public int SectionNodeId { get; set; }
 
-		public SectionBlogPostFilter() { }
-
 		public SectionBlogPostFilter(int sectionNodeId)
 		{
 			SectionNodeId = sectionNodeId;

--- a/Gibe.Umbraco.V7.Blog/Filters/SectionBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/SectionBlogPostFilter.cs
@@ -4,7 +4,7 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class SectionBlogPostFilter : IBlogPostFilter
 	{
-		public int SectionNodeId { get; set; }
+		public int SectionNodeId { get; }
 
 		public SectionBlogPostFilter(int sectionNodeId)
 		{

--- a/Gibe.Umbraco.V7.Blog/Filters/SectionBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/SectionBlogPostFilter.cs
@@ -4,16 +4,18 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class SectionBlogPostFilter : IBlogPostFilter
 	{
-		private readonly int _sectionNodeId;
+		public int SectionNodeId { get; set; }
+
+		public SectionBlogPostFilter() { }
 
 		public SectionBlogPostFilter(int sectionNodeId)
 		{
-			_sectionNodeId = sectionNodeId;
+			SectionNodeId = sectionNodeId;
 		}
 
 		public IBooleanOperation GetCriteria(IQuery query)
 		{
-			return query.Field("path", _sectionNodeId.ToString());
+			return query.Field("path", SectionNodeId.ToString());
 		}
 	}
 }

--- a/Gibe.Umbraco.V7.Blog/Filters/StandardBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/StandardBlogPostFilter.cs
@@ -4,8 +4,8 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class StandardBlogPostFilter : IBlogPostFilter
 	{
-		public string PropertyName { get; set; }
-		public string PropertyValue { get; set; }
+		public string PropertyName { get; }
+		public string PropertyValue { get; }
 
 		public StandardBlogPostFilter(string propertyName, string value)
 		{

--- a/Gibe.Umbraco.V7.Blog/Filters/StandardBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/StandardBlogPostFilter.cs
@@ -7,8 +7,6 @@ namespace Gibe.Umbraco.Blog.Filters
 		public string PropertyName { get; set; }
 		public string PropertyValue { get; set; }
 
-		public StandardBlogPostFilter() { }
-
 		public StandardBlogPostFilter(string propertyName, string value)
 		{
 			PropertyName = propertyName;

--- a/Gibe.Umbraco.V7.Blog/Filters/StandardBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/StandardBlogPostFilter.cs
@@ -4,18 +4,20 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class StandardBlogPostFilter : IBlogPostFilter
 	{
-		private readonly string _propertyName;
-		private readonly string _propertyValue;
+		public string PropertyName { get; set; }
+		public string PropertyValue { get; set; }
+
+		public StandardBlogPostFilter() { }
 
 		public StandardBlogPostFilter(string propertyName, string value)
 		{
-			_propertyName = propertyName;
-			_propertyValue = value;
+			PropertyName = propertyName;
+			PropertyValue = value;
 		}
 		
 		public IBooleanOperation GetCriteria(IQuery query)
 		{
-			return query.Field(_propertyName, _propertyValue);
+			return query.Field(PropertyName, PropertyValue);
 		}
 	}
 }

--- a/Gibe.Umbraco.V7.Blog/Filters/TagBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/TagBlogPostFilter.cs
@@ -7,8 +7,6 @@ namespace Gibe.Umbraco.Blog.Filters
 	{
 		public string Tag { get; set; }
 
-		public TagBlogPostFilter() { }
-
 		public TagBlogPostFilter(string tag)
 		{
 			Tag = tag;

--- a/Gibe.Umbraco.V7.Blog/Filters/TagBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/TagBlogPostFilter.cs
@@ -5,7 +5,7 @@ namespace Gibe.Umbraco.Blog.Filters
 {
 	public class TagBlogPostFilter : IBlogPostFilter
 	{
-		public string Tag { get; set; }
+		public string Tag { get; }
 
 		public TagBlogPostFilter(string tag)
 		{

--- a/Gibe.Umbraco.V7.Blog/Filters/TagBlogPostFilter.cs
+++ b/Gibe.Umbraco.V7.Blog/Filters/TagBlogPostFilter.cs
@@ -1,21 +1,22 @@
 ﻿using Examine.SearchCriteria;
-using Gibe.Umbraco.Blog.Models;
 using Gibe.Umbraco.Blog.Utilities;
 
 namespace Gibe.Umbraco.Blog.Filters
 {
 	public class TagBlogPostFilter : IBlogPostFilter
 	{
-		private readonly string _tag;
+		public string Tag { get; set; }
+
+		public TagBlogPostFilter() { }
 
 		public TagBlogPostFilter(string tag)
 		{
-			_tag = tag;
+			Tag = tag;
 		}
 		
 		public IBooleanOperation GetCriteria(IQuery query)
 		{
-			return query.Field("tag", new ExactPhraseExamineValue(_tag.ToLower()));
+			return query.Field("tag", new ExactPhraseExamineValue(Tag.ToLower()));
 		}
 	}
 }

--- a/Gibe.Umbraco.V7.Blog/Gibe.Umbraco.V7.Blog.csproj
+++ b/Gibe.Umbraco.V7.Blog/Gibe.Umbraco.V7.Blog.csproj
@@ -328,6 +328,8 @@
     <Compile Include="BlogSections.cs" />
     <Compile Include="BlogService.cs" />
     <Compile Include="BlogTags.cs" />
+    <Compile Include="Filters\AuthorBlogPostFilter.cs" />
+    <Compile Include="Filters\CategoryBlogPostFilter.cs" />
     <Compile Include="Filters\DateBlogPostFilter.cs" />
     <Compile Include="Filters\IBlogPostFilter.cs" />
     <Compile Include="Filters\SearchTermBlogPostFilter.cs" />

--- a/Gibe.Umbraco.V7.Blog/Sort/DateSort.cs
+++ b/Gibe.Umbraco.V7.Blog/Sort/DateSort.cs
@@ -4,7 +4,7 @@ namespace Gibe.Umbraco.Blog.Sort
 {
 	public class DateSort : ISort
 	{
-		public bool Descending { get; set; }
+		public bool Descending { get; }
 
 		public DateSort(bool descending = true)
 		{

--- a/Gibe.Umbraco.V7.Blog/Sort/DateSort.cs
+++ b/Gibe.Umbraco.V7.Blog/Sort/DateSort.cs
@@ -6,8 +6,6 @@ namespace Gibe.Umbraco.Blog.Sort
 	{
 		public bool Descending { get; set; }
 
-		public DateSort() { }
-
 		public DateSort(bool descending = true)
 		{
 			Descending = descending;

--- a/Gibe.Umbraco.V7.Blog/Sort/DateSort.cs
+++ b/Gibe.Umbraco.V7.Blog/Sort/DateSort.cs
@@ -1,24 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Examine.SearchCriteria;
+﻿using Examine.SearchCriteria;
 
 namespace Gibe.Umbraco.Blog.Sort
 {
 	public class DateSort : ISort
 	{
-		private readonly bool _descending;
+		public bool Descending { get; set; }
+
+		public DateSort() { }
 
 		public DateSort(bool descending = true)
 		{
-			_descending = descending;
+			Descending = descending;
 		}
 
 		public IBooleanOperation GetCriteria(IBooleanOperation query)
 		{
-			if (_descending)
+			if (Descending)
 			{
 				return query.And().OrderByDescending("postDate");
 			}


### PR DESCRIPTION
For BR we're making the blog headless.  In order to serialize the `IBlogPostFilter`/`ISort` classes to JSON, we need to expose the private fields.  I originally was using reflection for this to save updating the v7 & v10 packages, but after chatting to @aheaford we decided to bite the bullet and change both packages.

We've already done this in the v10 version in [these commits](https://github.com/Gibe/Gibe.Umbraco.Blog/pull/30/files/9eb9d416cb12d7b940bc99237a8c92d3f7f201d0..36cefa9b4e93d14b1ce36470067814bab9bb89e9) in PR https://github.com/Gibe/Gibe.Umbraco.Blog/pull/30

The guts of the changes are:
* Expose private fields as public properties so they can be serialized/deserialized
* Add in a couple of newer filters that are available in v10 so that we can more easily dual-target between netcore/framework between the v7&v10 versions of the package.